### PR TITLE
feat(sauvegardes): Ajoute le lancement de sauvegarde manuelle (#19)

### DIFF
--- a/app/Livewire/Client/Account/Sauvegardes.php
+++ b/app/Livewire/Client/Account/Sauvegardes.php
@@ -3,10 +3,12 @@
 namespace App\Livewire\Client\Account;
 
 use App\Models\Customer\Customer;
+use App\Models\Customer\CustomerService;
 use App\Models\Customer\CustomerServiceBackup;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -37,7 +39,7 @@ class Sauvegardes extends Component implements HasActions, HasSchemas, HasTable
     public function table(Table $table): Table
     {
         return $table
-                ->query(CustomerServiceBackup::where('customer_id', $this->customer->id))
+                ->query(CustomerServiceBackup::where('customer_id', $this->customer->id)->newQuery())
                 ->columns([
                     TextColumn::make('created_at')
                         ->label('Date de sauvegarde')
@@ -47,6 +49,42 @@ class Sauvegardes extends Component implements HasActions, HasSchemas, HasTable
                         ->label('Service Associé')
                         ->formatStateUsing(function (?Model $record) {
                             return $record->customerService->service_code;
+                        }),
+                ])
+                ->headerActions([
+                    Action::make('save')
+                        ->label("Lancer une sauvegarde")
+                        ->schema([
+                            Select::make('customer_service_id')
+                                ->label("Service")
+                                ->options($this->customer->services()->pluck('service_code', 'id')),
+                        ])
+                        ->action(function (array $data) {
+                            try {
+                                $service = CustomerService::find($data['customer_service_id']);
+                                $request = Http::withoutVerifying()
+                                    ->timeout(60)
+                                    ->get('https://'.$service->domain.'/api/core/backup');
+
+                                if ($request->successful()) {
+                                    $service->backups()->create(['created_at' => now()]);
+
+                                    Notification::make()
+                                        ->success()
+                                        ->title('Sauvegarde téléchargée avec succès')
+                                        ->send();
+                                } else {
+                                    Notification::make()
+                                        ->danger()
+                                        ->title('Erreur lors du téléchargement de la sauvegarde')
+                                        ->send();
+                                }
+                            } catch (\Exception $e) {
+                                Notification::make()
+                                    ->danger()
+                                    ->title('Erreur Server')
+                                    ->send();
+                            }
                         }),
                 ])
                 ->recordActions([

--- a/resources/views/livewire/client/account/sauvegardes.blade.php
+++ b/resources/views/livewire/client/account/sauvegardes.blade.php
@@ -1,7 +1,8 @@
 <div>
     <x-mary-header
-        title="Mes Sauvegardes"        
+        title="Mes Sauvegardes"
     />
 
     {{ $this->table }}
+    <x-filament-actions::modals />
 </div>


### PR DESCRIPTION
Cette fonctionnalité permet aux clients de déclencher manuellement une sauvegarde pour un de leurs services depuis leur espace client.

Un bouton "Lancer une sauvegarde" a été ajouté dans l'en-tête du tableau. Il ouvre une modale pour sélectionner le service concerné. Une requête API est ensuite envoyée pour initier la sauvegarde, et des notifications informent l'utilisateur du résultat.

Close: #20 